### PR TITLE
check key in value, json parser only on str

### DIFF
--- a/backend/endpoints/api/v1/restapi.py
+++ b/backend/endpoints/api/v1/restapi.py
@@ -383,7 +383,7 @@ class RestAPI:
         db = MovaiDB("global")
         robot_id = None
         for key, val in db.search_by_args(scope="Robot")[0]["Robot"].items():
-            if val["RobotName"] == robot_name:
+            if "RobotName" in val and val["RobotName"] == robot_name:
                 robot_id = key
                 break
         if robot_id is None:
@@ -416,9 +416,11 @@ class RestAPI:
             status = 401
             output = {"error": str(e)}
         else:
-            output = response.text
+            try:
+                output = json.loads(response.text)
+            except json.JSONDecodeError as e:
+                output = {"error": f"error decoding response {e}"}
 
-        output = json.loads(output)
         return web.json_response(output, status=status)
 
     async def get_permissions(self, request):


### PR DESCRIPTION
BP-629
[ERROR][2022-05-26 15:38:16][web_protocol][log_exception][355]: Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/opt/mov.ai/app/deprecated/gdnode/protocols/restapi.py", line 139, in middleware
    return await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/opt/mov.ai/app/deprecated/gdnode/protocols/restapi.py", line 145, in save_node_type
    response = await handler(request)
  File "/opt/mov.ai/app/deprecated/gdnode/protocols/restapi.py", line 170, in remove_flow_exposed_port_links
    response = await handler(request)
  File "/opt/mov.ai/app/deprecated/gdnode/protocols/restapi.py", line 222, in redirect_not_found
    response = await handler(request)
  File "/opt/mov.ai/app/deprecated/gdnode/protocols/restapi.py", line 408, in get_robot_logs
    output = json.loads(output)
  File "/usr/lib/python3.6/json/__init__.py", line 348, in loads
    'not {!r}'.format(s.__class__.__name__))
TypeError: the JSON object must be str, bytes or bytearray, not 'dict'

BP-633
WARNING][2022-06-06 11:17:20][acl.py][get_acl][service:backend][222]: Invalid User Role: expected string or bytes-like object
[WARNING][2022-06-06 11:17:20][acl.py][get_acl][222]: Invalid User Role: expected string or bytes-like object
[ERROR][2022-06-06 11:17:20][web_protocol][log_exception][355]: Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/opt/mov.ai/app/deprecated/gdnode/protocols/restapi.py", line 139, in middleware
    return await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/opt/mov.ai/app/deprecated/gdnode/protocols/restapi.py", line 145, in save_node_type
    response = await handler(request)
  File "/opt/mov.ai/app/deprecated/gdnode/protocols/restapi.py", line 170, in remove_flow_exposed_port_links
    response = await handler(request)
  File "/opt/mov.ai/app/deprecated/gdnode/protocols/restapi.py", line 222, in redirect_not_found
    response = await handler(request)
  File "/opt/mov.ai/app/deprecated/gdnode/protocols/restapi.py", line 370, in get_robot_logs
    if val['RobotName'] == robot_name:
KeyError: 'RobotName'
