### PR TITLE
fix for ladp injection and xss attack

### DIFF
--- a/backend/endpoints/auth.py
+++ b/backend/endpoints/auth.py
@@ -17,9 +17,8 @@
 # pylint: disable=broad-except
 
 from typing import Union, List
-
+from ldap3.utils.conv import escape_filter_chars
 import aiohttp_cors
-
 from aiohttp import web
 
 # Todo : check if there is a copy to the dal
@@ -80,8 +79,11 @@ class AuthApp(IWebApp):
         """Get API Token"""
         try:
             data = await request.json()
-
-            user_obj = User(data["username"])
+            username = data["username"]
+            if  username != escape_filter_chars(username):
+                # Check for ldap injection
+                raise ValueError("invalid username")
+            user_obj = User(username)
 
             if not user_obj.verify_password(data["password"]):
                 raise ValueError("invalid username/password")

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ with open("README.md", "r") as fh:
 # The 'install_requires' is where you specify the package dependencies of your package. They will be automaticly installed, before your package.  # noqa: E501
 
 requirements = [
+    "bleach==4.1.0",
+    "ldap3==2.9.1",
     "aiohttp==3.6.2",
     "aiohttp-cors==0.7.0",
     "requests==2.22.0",
@@ -30,6 +32,6 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     classifiers=["Programming Language :: Python :: 3"],
-    install_requires=requirements, 
+    install_requires=requirements,
     entry_points={},
 )


### PR DESCRIPTION
By default, when we request to open front-end application, URL parameters might be passed, and those parameters are returned back in the response.

But when there’s malicious scripting in the URL parameters, they are not executed, but they’re also returned in the response. We should block the request raising some exceptions and not rendering the app if it contains scripting.

What I did here in this PR is just decode the request params and check if they contain scripting, but might be other types of malicious code that should also be prevented, and back-end team might have better ideas of implementation to fix this.

This PR is meant to fix two types of vulnerabilities caught by Qualys scan:

https://movai.atlassian.net/browse/BP-571

https://movai.atlassian.net/browse/BP-572


