### PR TITLE
version 2.4.1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,3 @@ For ROS noetic distribution :
     export BACKEND_DISTRO=noetic
     docker-compose -f tests/docker-compose.yml up -d
 
-


### PR DESCRIPTION
movai-core-shared updated: 2.4.1.8 => 2.4.1.9
revert [BP-957](https://movai.atlassian.net/browse/BP-957) - removing tags from log message

[BP-957]: https://movai.atlassian.net/browse/BP-957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ