### PR TITLE
BP-989 - separate metrics to different measurements in influxdb

### DIFF
--- a/backend/endpoints/api/v1/restapi.py
+++ b/backend/endpoints/api/v1/restapi.py
@@ -159,7 +159,15 @@ class RestAPI:
         except Exception as exc:
             raise web.HTTPBadRequest(reason=str(exc), headers={"Server": "Movai-server"})
 
-    def fetch_request_params(self, request: dict):
+    def fetch_request_params(self, request: dict) -> dict:
+        """fetches the params from the request and returns them in a dictionary.
+
+        Args:
+            request (dict): The request with the params.
+
+        Returns:
+            dict: A dictionary of params and their value.
+        """
         params = {}
         for param in request.query_string.split("&"):
             name, value = param.split("=")

--- a/backend/endpoints/api/v1/restapi.py
+++ b/backend/endpoints/api/v1/restapi.py
@@ -274,7 +274,7 @@ class RestAPI:
             status = 200
             metrics = Metrics()
             output = metrics.get_metrics(
-                name=name,
+                measurement=name,
                 limit=limit,
                 offset=offset,
                 tags=tags.split(",") if tags else [],

--- a/backend/endpoints/api/v1/restapi.py
+++ b/backend/endpoints/api/v1/restapi.py
@@ -277,7 +277,7 @@ class RestAPI:
         try:
             status = 200
             metrics = Metrics()
-            output = await metrics.get_metrics(
+            output = metrics.get_metrics(
                 **params,
                 tags=tags,
                 pagination=True,

--- a/backend/endpoints/api/v1/restapi.py
+++ b/backend/endpoints/api/v1/restapi.py
@@ -159,6 +159,13 @@ class RestAPI:
         except Exception as exc:
             raise web.HTTPBadRequest(reason=str(exc), headers={"Server": "Movai-server"})
 
+    def fetch_request_params(self, request: dict):
+        params = {}
+        for param in request.query_string.split("&"):
+            name, value = param.split("=")
+            params[name] = value
+        return params
+
     async def get_logs(self, request) -> web.Response:
         """Get logs from HealthNode using get_logs in Logger class
         path:
@@ -173,12 +180,8 @@ class RestAPI:
             tags
             services
         """
-        params = {}
-        for param in request.query_string.split("&"):
-            name, value = param.split("=")
-            params[name] = value
+        params = self.fetch_request_params(request)
 
-        # empty list, request should be sent to health-node directly
         try:
             status = 200
             output = LogsQuery.get_logs(pagination=True, **params)
@@ -263,21 +266,20 @@ class RestAPI:
         if not ENTERPRISE:
             output = {"error": "movai-core-enterprise is not installed."}
             return output
-        name = request.rel_url.query.get("name")
-        limit = request.rel_url.query.get("limit", 1000)
-        offset = request.rel_url.query.get("offset", 0)
-        tags = request.rel_url.query.get("tags")
 
+        params = self.fetch_request_params(request)
         # Fetch all responses within one Client session,
         # keep connection alive for all requests.
+        if params.get("tags") is not None:
+            tags = params["tags"].split(",")
+        else:
+            tags = []
         try:
             status = 200
             metrics = Metrics()
             output = metrics.get_metrics(
-                measurement=name,
-                limit=limit,
-                offset=offset,
-                tags=tags.split(",") if tags else [],
+               **params,
+                tags=tags,
                 pagination=True,
             )
         except Exception as exc:

--- a/backend/endpoints/api/v1/restapi.py
+++ b/backend/endpoints/api/v1/restapi.py
@@ -277,8 +277,8 @@ class RestAPI:
         try:
             status = 200
             metrics = Metrics()
-            output = metrics.get_metrics(
-               **params,
+            output = await metrics.get_metrics(
+                **params,
                 tags=tags,
                 pagination=True,
             )

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ requirements = [
     "miracle-acl==0.0.4.post1",
     "PyYAML==5.1.2",
     "requests==2.22.0",
-    "movai-core-shared==2.4.1.10",
-    "data-access-layer==2.4.1.18",
-    "gd-node==2.4.1.13",
+    "movai-core-shared==2.4.1.12",
+    "data-access-layer==2.4.1.20",
+    "gd-node==2.4.1.14",
 ]
 
 


### PR DESCRIPTION
[BP-989](https://movai.atlassian.net/browse/BP-989) - separate metrics to different measurements in influxdb

DAL:
    [BP-771](https://movai.atlassian.net/browse/BP-771): Fleet var mentioned on a node parameter is not correctly parsed.
    [BP-958](https://movai.atlassian.net/browse/BP-958): Task manager - err in generating tasks
    [BP-1020](https://movai.atlassian.net/browse/BP-1020): Installation of packages inside flow-initiator hang if it was not started as a robot

shared:
    [BP-995](https://movai.atlassian.net/browse/BP-995): Alerts silently breaking in 2.4
    [BP-1019](https://movai.atlassian.net/browse/BP-1019): New spam log
    [BP-1023](https://movai.atlassian.net/browse/BP-1023): display message server messages in readable format

gd-node:
    [BP-996](https://movai.atlassian.net/browse/BP-996): Not possible to upload assets to Package

[BP-989]: https://movai.atlassian.net/browse/BP-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BP-771]: https://movai.atlassian.net/browse/BP-771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-958]: https://movai.atlassian.net/browse/BP-958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-1020]: https://movai.atlassian.net/browse/BP-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-995]: https://movai.atlassian.net/browse/BP-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-1019]: https://movai.atlassian.net/browse/BP-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-1023]: https://movai.atlassian.net/browse/BP-1023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-996]: https://movai.atlassian.net/browse/BP-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ