### PR TITLE
version 2.4.1.24 Bugfixes

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -15,6 +15,7 @@ from concurrent.futures import ThreadPoolExecutor
 from aiohttp import web
 
 from dal.data.shared.vault import JWT_SECRET_KEY
+from dal.models.role import Role
 
 from gd_node.protocols.http.middleware import JWTMiddleware
 
@@ -102,6 +103,8 @@ def main():
         # and add to the root
         main_app.add_subapp(http_prefix, webapp)
 
+    # create default role
+    Role.create_default_roles()
     # start the application
     # runs until interrupted
     web.run_app(main_app, host=HTTP_HOST, port=HTTP_PORT)

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ requirements = [
     "miracle-acl==0.0.4.post1",
     "PyYAML==5.1.2",
     "requests==2.22.0",
-    "movai-core-shared==2.4.1.13",
+    "movai-core-shared==2.4.1.14",
     "data-access-layer==2.4.1.22",
-    "gd-node==2.4.1.15",
+    "gd-node==2.4.1.16",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
     "PyYAML==5.1.2",
     "requests==2.22.0",
     "movai-core-shared==2.4.1.13",
-    "data-access-layer==2.4.1.21",
+    "data-access-layer==2.4.1.22",
     "gd-node==2.4.1.15",
 ]
 


### PR DESCRIPTION
[BP-982](https://movai.atlassian.net/browse/BP-982): Spawner dies and restarts when running a flow
backend dies because of destroy (not thread safe), need to close socket and call term instead.
changes tested and working fine with api_tests
[BP-1025](https://movai.atlassian.net/browse/BP-1025) - logs from spawner are not displayed