### PR TITLE
Version 2.4.1.28

### DIFF
--- a/backend/endpoints/static.py
+++ b/backend/endpoints/static.py
@@ -96,8 +96,8 @@ class StaticApp(IWebApp):
                 None, self._fetch_file_from_redis, package_name, package_file
             )
 
-            if output is None:
-                raise web.HTTPNotFound()
+            if not output:
+                raise web.HTTPNotFound(reason=f"package:{package_name}, file:{package_file}")
 
             # guess content type
             content_type = guess_type(package_file)[0]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
     "PyYAML==5.1.2",
     "requests==2.22.0",
     "movai-core-shared==2.4.1.16",
-    "data-access-layer==2.4.1.27",
+    "data-access-layer==2.4.1.28",
     "gd-node==2.4.1.16",
 ]
 


### PR DESCRIPTION
- [BP-1033](https://movai.atlassian.net/browse/BP-1033): Get on maps endpoint for inexisting map returns 200
- [BP-1034](https://movai.atlassian.net/browse/BP-1034) - Subscriber to redis returns nothing

[BP-1033]: https://movai.atlassian.net/browse/BP-1033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BP-1034]: https://movai.atlassian.net/browse/BP-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ