### PR TITLE
version 2.4.1.29

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
     "PyYAML==5.1.2",
     "requests==2.22.0",
     "movai-core-shared==2.4.1.16",
-    "data-access-layer==2.4.1.28",
+    "data-access-layer==2.4.1.29",
     "gd-node==2.4.1.16",
 ]
 


### PR DESCRIPTION
[BP-1034](https://movai.atlassian.net/browse/BP-1034) - subscriber to redis returns nothing
[BP-1031](https://movai.atlassian.net/browse/BP-1034) - Connection error Cannot write to closing transport

[BP-1034]: https://movai.atlassian.net/browse/BP-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-1031]: https://movai.atlassian.net/browse/BP-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ