### PR TITLE
2.4 : Release new base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,3 @@ For ROS noetic distribution :
     python3 -m build .
     export BACKEND_DISTRO=noetic
     docker-compose -f tests/docker-compose.yml up -d
-

--- a/docker/noetic/Dockerfile
+++ b/docker/noetic/Dockerfile
@@ -1,5 +1,5 @@
 ARG DOCKER_REGISTRY="pubregistry.aws.cloud.mov.ai"
-FROM ${DOCKER_REGISTRY}/ce/movai-base-focal:v2.4.0
+FROM ${DOCKER_REGISTRY}/ce/movai-base-focal:v2.4.2
 
 # Arguments
 ARG PIP_PACKAGE_REPO="https://artifacts.cloud.mov.ai/repository/pypi-experimental/simple"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
     "PyYAML==5.1.2",
     "requests==2.22.0",
     "movai-core-shared==2.4.1.16",
-    "data-access-layer==2.4.1.29",
+    "data-access-layer==2.4.1.30",
     "gd-node==2.4.1.16",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
     "PyYAML==5.4",
     "requests==2.22.0",
     "movai-core-shared==2.4.1.16",
-    "data-access-layer==2.4.1.30",
+    "data-access-layer==2.4.1.31",
     "gd-node==2.4.1.16",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
     "bleach==4.1.0",
     "ldap3==2.9.1",
     "miracle-acl==0.0.4.post1",
-    "PyYAML==5.1.2",
+    "PyYAML==5.4",
     "requests==2.22.0",
     "movai-core-shared==2.4.1.16",
     "data-access-layer==2.4.1.30",


### PR DESCRIPTION
Fix:
- new base image: DP-1155, see #137
- updating DAL to 2.4.1.31: for a fix on [BP-1042](https://movai.atlassian.net/browse/BP-1042)- FE freeze
- resolve a critical severity Dependabot alert on PyYAML #4 

---
- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[BP-1042]: https://movai.atlassian.net/browse/BP-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ