### PR TITLE
DP-1239 wrong version on container images

### DIFF
--- a/.github/workflows/DeployOnGitRelease.yml
+++ b/.github/workflows/DeployOnGitRelease.yml
@@ -40,6 +40,7 @@ jobs:
       public: true
       public_image: ce/backend-noetic
       deploy: true
+      version: ${GITHUB_REF#refs/*/}
       push_latest: true
       snyk_check: true
       build_args: PIP_PACKAGE_REPO=https://artifacts.cloud.mov.ai/repository/pypi-edge/simple

--- a/.github/workflows/DeployOnMergeMain.yml
+++ b/.github/workflows/DeployOnMergeMain.yml
@@ -51,6 +51,7 @@ jobs:
       public: false
       public_image: ce/backend-noetic
       deploy: true
+      version: ${{ needs.CI-version.outputs.version }}
       push_latest: true
       snyk_check: true
       build_args: PIP_PACKAGE_REPO=https://artifacts.cloud.mov.ai/repository/pypi-integration/simple

--- a/.github/workflows/TestOnPR.yml
+++ b/.github/workflows/TestOnPR.yml
@@ -56,6 +56,7 @@ jobs:
       public: false
       public_image: ce/backend-noetic
       deploy: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v')}}
+      version: ${{ needs.CI-version.outputs.version }}
       push_latest: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v') }}
       snyk_check: true
       build_args: PIP_PACKAGE_REPO=https://artifacts.cloud.mov.ai/repository/pypi-experimental/simple


### PR DESCRIPTION
Add 'version' input to docker image action.

Pipeline Run:

------------------

- [ ] Make sure you are opening from a **topic/feature/bugfix branch**
- [ ] Ensure that the PR title represents the desired changes
- [ ] Ensure that the PR description detail the desired changes
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
