### PR TITLE
BP-1037, BP-1038: check if port need to be removed

### DIFF
--- a/backend/endpoints/api/v1/restapi.py
+++ b/backend/endpoints/api/v1/restapi.py
@@ -926,7 +926,8 @@ class RestAPI:
             for scope_obj in scope_updates:
                 to_delete = scope_obj.get("to_delete")
                 if to_delete:
-                    if list(to_delete.keys())[0] == "PortsInst" and scope == "Node":
+                    if list(to_delete.keys())[0] == "PortsInst" and scope == "Node" \
+                        and list(to_delete["PortsInst"].keys())[0] not in new_dict["PortsInst"]:
                         port_name = list(to_delete["PortsInst"].keys())[0]
                         if port_name not in deleted:
                             # in case we are deleting a Port from node, then use the regular delete

--- a/backend/endpoints/api/v1/restapi.py
+++ b/backend/endpoints/api/v1/restapi.py
@@ -115,7 +115,6 @@ class RestAPI:
         }
         self.scope_classes.update(enterprise_scope)
 
-    
     async def cloud_func(self, request):
         """Run specific callback"""
         callback_name = request.match_info["cb_name"]
@@ -152,8 +151,6 @@ class RestAPI:
             )
         except Exception as exc:
             raise web.HTTPBadRequest(reason=str(exc), headers={"Server": "Movai-server"})
-
-
 
     async def get_logs(self, request) -> web.Response:
         """Get logs from HealthNode using get_logs in Logger class
@@ -929,7 +926,10 @@ class RestAPI:
                     key, value = to_delete.popitem()
                     if key == "PortsInst" and scope == "Node":
                         port_name = list(value.keys())[0]
-                        if port_name not in new_dict["PortsInst"] and port_name not in ports_deleted:
+                        if (
+                            port_name not in new_dict["PortsInst"]
+                            and port_name not in ports_deleted
+                        ):
                             # in case we are deleting a Port from node, then use the regular delete
                             # in order to delete the exposedPorts from flows
                             Node(_id).delete("PortsInst", port_name)

--- a/backend/endpoints/api/v1/restapi.py
+++ b/backend/endpoints/api/v1/restapi.py
@@ -921,20 +921,20 @@ class RestAPI:
 
             pipe = movai_db.create_pipe()
 
-            deleted = []
+            ports_deleted = []
             scope_updates = scope_obj.calc_scope_update(old_dict, new_dict)
             for scope_obj in scope_updates:
                 to_delete = scope_obj.get("to_delete")
                 if to_delete:
-                    if list(to_delete.keys())[0] == "PortsInst" and scope == "Node" \
-                        and list(to_delete["PortsInst"].keys())[0] not in new_dict["PortsInst"]:
-                        port_name = list(to_delete["PortsInst"].keys())[0]
-                        if port_name not in deleted:
+                    key, value = to_delete.popitem()
+                    if key == "PortsInst" and scope == "Node":
+                        port_name = list(value.keys())[0]
+                        if port_name not in new_dict["PortsInst"] and port_name not in ports_deleted:
                             # in case we are deleting a Port from node, then use the regular delete
                             # in order to delete the exposedPorts from flows
                             Node(_id).delete("PortsInst", port_name)
-                            deleted.append(port_name)
-                    movai_db.unsafe_delete({scope: {_id: to_delete}}, pipe=pipe)
+                            ports_deleted.append(port_name)
+                    movai_db.unsafe_delete({scope: {_id: {key: value}}}, pipe=pipe)
 
                 to_set = scope_obj.get("to_set")
                 if to_set:


### PR DESCRIPTION
- [BP-1037](https://movai.atlassian.net/browse/BP-1037) / [BP-1038](https://movai.atlassian.net/browse/BP-1038):  Error when saving Node, when a port has changed from subscriber to publisher
  -  before fully deleting a port we need to check if that port really exist/not in the new_dict from the POST request.

[BP-1037]: https://movai.atlassian.net/browse/BP-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BP-1038]: https://movai.atlassian.net/browse/BP-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ