### PR TITLE
BP-1104: fixed alerts issue when does not exist in redis

### DIFF
--- a/backend/endpoints/api/v2/alerts.py
+++ b/backend/endpoints/api/v2/alerts.py
@@ -58,11 +58,10 @@ async def set_alerts_config(request: web.Request):
     if "alerts" not in data:
         raise web.HTTPBadRequest(reason="alerts not in data")
 
-    alerts = data["alerts"] if "alerts" in data else []
     _check_user_permission(request, "EmailsAlertsConfig", "update")
 
     alertsConfig = AlertsConfig.db_get()
-    alertsConfig.alerts = alerts
+    alertsConfig.alerts = data["alerts"]
     alertsConfig.db_set()
 
     return web.json_response(
@@ -80,11 +79,10 @@ async def set_alerts_emails(request: web.Request):
     if "emails" not in data:
         raise web.HTTPBadRequest(reason="\"emails\" not in data")
 
-    recipients = data["emails"] if "emails" in data else []
     _check_user_permission(request, "EmailsAlertsRecipients", "update")
 
     alertsConfig = AlertsConfig.db_get()
-    alertsConfig.emails = recipients
+    alertsConfig.emails = data["emails"]
     alertsConfig.db_set()
 
     return web.json_response(

--- a/backend/endpoints/api/v2/alerts.py
+++ b/backend/endpoints/api/v2/alerts.py
@@ -20,8 +20,8 @@ from dal.models.var import Var
 
 
 class AlertsConfig(BaseModel):
-    """pydantic class in order to validate
-    """
+    """pydantic class in order to validate"""
+
     emails: List[EmailStr] = Field(default_factory=list)
     alerts: List[str] = Field(default_factory=list)
 
@@ -77,7 +77,7 @@ async def set_alerts_emails(request: web.Request):
     except json.decoder.JSONDecodeError:
         raise web.HTTPBadRequest(reason="emails not in data")
     if "emails" not in data:
-        raise web.HTTPBadRequest(reason="\"emails\" not in data")
+        raise web.HTTPBadRequest(reason='"emails" not in data')
 
     _check_user_permission(request, "EmailsAlertsRecipients", "update")
 
@@ -89,7 +89,6 @@ async def set_alerts_emails(request: web.Request):
         alertsConfig.dict(),
         headers={"Server": "Movai-server"},
     )
-
 
 
 async def get_alerts_emails(request: web.Request) -> web.json_response:
@@ -125,4 +124,3 @@ class EmailsAlertsAPI(BaseWebApp):
 
 
 WebAppManager.register("/api/v2/alerts", EmailsAlertsAPI)
-

--- a/backend/endpoints/api/v2/alerts.py
+++ b/backend/endpoints/api/v2/alerts.py
@@ -93,9 +93,11 @@ async def set_alerts_emails(request: web.Request):
             if m is not None:
                 errors.append(data["emails"][int(m.group(1))])
         if errors:
-            return web.json_response({"error": f"[{','.join(errors)}] is not a valid email address(s)"}, status=400)
+            return web.json_response(
+                {"error": f"[{','.join(errors)}] is not a valid email address(s)"}, status=400
+            )
         return web.json_response({"error": str(e)}, status=500)
-            
+
     alertsConfig.db_set()
 
     return web.json_response(

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ requirements = [
     "miracle-acl==0.0.4.post1",
     "PyYAML==6.0",
     "requests==2.28.2",
+    "pydantic==1.10.4",
+    "pydantic[email]",
     "movai-core-shared==2.4.1.36",
     "data-access-layer==2.4.1.36",
     "gd-node==2.4.1.21",


### PR DESCRIPTION
- [BP-1104](https://movai.atlassian.net/browse/BP-1104): Alerts config and emails api's don't save the data on redis
  - there was a small issue in case the var does not exist in redis so it won't work, I have refactored the code and added a pydantic validation for the inputs as well.
  - tested

[BP-1104]: https://movai.atlassian.net/browse/BP-1104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ