### PR TITLE
Version 2.5.0.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
     "requests==2.28.2",
     "email-validator==2.0.0",
     "pytz==2022.7.1",
-    "movai-core-shared==2.5.0.6",
+    "movai-core-shared==2.5.0.9",
     "data-access-layer==2.5.0.6",
     "gd-node==2.5.0.5",
 ]


### PR DESCRIPTION
[BP-872](https://movai.atlassian.net/browse/BP-872) - convert frontend callback to rest api

fix missing exception from mvoai-core-shared

[BP-872]: https://movai.atlassian.net/browse/BP-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ