### PR TITLE
Align gd-node version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "pytz==2022.7.1",
     "movai-core-shared==2.5.0.12",
     "data-access-layer==2.5.0.12",
-    "gd-node==2.5.0.6",
+    "gd-node==2.5.0.9",
 ]
 
 


### PR DESCRIPTION
- [BP-1187](https://movai.atlassian.net/browse/BP-1187): Align released versions 
  - Bump gd-node to align versions, see https://github.com/MOV-AI/gd-node/pull/104

[BP-1187]: https://movai.atlassian.net/browse/BP-1187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ