### PR TITLE
Version 2.4.2.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     "email-validator==2.0.0",
     "pytz==2022.7.1",
     "movai-core-shared==2.5.0.12",
-    "data-access-layer==2.5.0.12",
+    "data-access-layer==2.5.0.13",
     "gd-node==2.5.0.9",
 ]
 


### PR DESCRIPTION
Update DAL to [2.5.0.13](https://github.com/MOV-AI/data-access-layer/releases/tag/2.5.0.13) in order to apply fix for [BP-1166](https://movai.atlassian.net/browse/BP-1166).

[BP-1166]: https://movai.atlassian.net/browse/BP-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ