### PR TITLE
BP-1210 Subscription to changes on redis via ws/subscribe fails silently

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -4,6 +4,6 @@ pytest-cov
 mock
 bump2version
 flake8
-pylint
+pylint==v3.1.1
 black
 tox

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -4,6 +4,6 @@ pytest-cov
 mock
 bump2version
 flake8
-pylint==v3.1.1
+pylint
 black
 tox

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
     "email-validator==2.0.0",
     "pytz==2022.7.1",
     "movai-core-shared==2.5.0.14",
-    "data-access-layer==2.5.0.17",
+    "data-access-layer==2.5.0.18",
     "gd-node==2.5.0.10",
 ]
 


### PR DESCRIPTION
[BP-1210](https://movai.atlassian.net/browse/BP-1210) Update to the latest data-acces-layer, which contains a fix to close redis connections when websocket session ends

[BP-1210]: https://movai.atlassian.net/browse/BP-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ