### PR TITLE
Pin version of yarl library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ with open("README.md", "r") as fh:
 requirements = [
     "aiohttp==3.8.1",
     "aiohttp-cors==0.7.0",
+    "yarl==1.12.1",
     "bleach==4.1.0",
     "ldap3==2.9.1",
     "miracle-acl==0.0.4.post1",


### PR DESCRIPTION
Newer versions have a bug with the version of aiohttp that we use. Until we upgrade aiohttp, we have to pin this library.

Reference: https://github.com/aio-libs/aiohttp/pull/9309